### PR TITLE
Rename "active" field to "is_active" in shared collections

### DIFF
--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/mongodb/OpenScienceFrameworkPersonalAccessTokenHandler.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/mongodb/OpenScienceFrameworkPersonalAccessTokenHandler.java
@@ -48,7 +48,7 @@ public class OpenScienceFrameworkPersonalAccessTokenHandler extends AbstractPers
         @Field("user_id")
         private String userId;
         private String scopes;
-        private Boolean active;
+        private Boolean is_active;
 
         public String getUserId() {
             return this.userId;
@@ -59,7 +59,7 @@ public class OpenScienceFrameworkPersonalAccessTokenHandler extends AbstractPers
         }
 
         public Boolean getActive() {
-            return this.active;
+            return this.is_active;
         }
 
         @Override
@@ -77,7 +77,7 @@ public class OpenScienceFrameworkPersonalAccessTokenHandler extends AbstractPers
         final OpenScienceFrameworkPersonalToken token = this.mongoTemplate.findOne(new Query(
                 new Criteria().andOperator(
                         Criteria.where("token_id").is(tokenId),
-                        Criteria.where("active").is(true)
+                        Criteria.where("is_active").is(true)
                 )
         ), OpenScienceFrameworkPersonalToken.class);
 

--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/mongodb/OpenScienceFrameworkScopeHandler.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/mongodb/OpenScienceFrameworkScopeHandler.java
@@ -42,7 +42,7 @@ public class OpenScienceFrameworkScopeHandler extends AbstractScopeHandler
         private String id;
         private String name;
         private String description;
-        private Boolean active;
+        private Boolean is_active;
 
         public String getName() {
             return this.name;
@@ -53,7 +53,7 @@ public class OpenScienceFrameworkScopeHandler extends AbstractScopeHandler
         }
 
         public Boolean getActive() {
-            return this.active;
+            return this.is_active;
         }
 
         @Override
@@ -71,7 +71,7 @@ public class OpenScienceFrameworkScopeHandler extends AbstractScopeHandler
         final OpenScienceFrameworkScope scope = this.mongoTemplate.findOne(new Query(
                 new Criteria().andOperator(
                         Criteria.where("name").is(name),
-                        Criteria.where("active").is(true)
+                        Criteria.where("is_active").is(true)
                 )
         ), OpenScienceFrameworkScope.class);
 

--- a/cas-server-support-osf/src/main/java/io/cos/cas/services/OpenScienceFrameworkServiceRegistryDao.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/services/OpenScienceFrameworkServiceRegistryDao.java
@@ -67,7 +67,7 @@ public class OpenScienceFrameworkServiceRegistryDao implements ServiceRegistryDa
         private String clientId;
         @Field("client_secret")
         private String clientSecret;
-        private Boolean active;
+        private Boolean is_active;
 
         public String getId() {
             return this.id;
@@ -114,11 +114,11 @@ public class OpenScienceFrameworkServiceRegistryDao implements ServiceRegistryDa
         }
 
         public Boolean getActive() {
-            return this.active;
+            return this.is_active;
         }
 
-        public void setActive(Boolean active) {
-            this.active = active;
+        public void setActive(Boolean is_active) {
+            this.is_active = is_active;
         }
 
         @Override
@@ -149,7 +149,7 @@ public class OpenScienceFrameworkServiceRegistryDao implements ServiceRegistryDa
     @Override
     public final synchronized List<RegisteredService> load() {
         List<OAuth> oAuthServices = this.mongoTemplate.find(new Query(Criteria
-                .where("active").is(true)
+                .where("is_active").is(true)
         ), OAuth.class);
 
         ReturnAllowedAttributeReleasePolicy attributeReleasePolicy = new ReturnAllowedAttributeReleasePolicy();


### PR DESCRIPTION
## Purpose

Per @sloria comment on CenterForOpenScience/osf.io/pull/3082, rename "active" fields to "is_active" for better consistency with other OSF models.

## Summary of changes

Rename fields (and change DB queries) for the three mongo collections shared between the OSF and CAS:
- ApiOAuth2Application
-ApiOAuth2Scope
- ApiOAuth2PersonalToken

This change is made on top of the feature/oauth-scope branch.

## Deployment considerations
Will need to be accompanied by a matching change to OSF models when rolled out. (as well as any migration of existing data, if the PR is deployed farther in the future)